### PR TITLE
Correct a negated statement in the README (and whitespace)

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -34,7 +34,7 @@ Dive in...
 
     poster.kind_of?(User)     # => true
     poster.instance_of?(User) # => true
-    
+
     poster.class.name # => "User"
   end
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -52,8 +52,8 @@ Dive in...
 
 == The Problem
 
-So what's wrong with just using <tt>Object#extend</tt>?  Nothing, until you want to alter an instance's class
-as a side effect of adorning it with a role... which happens often when using ActiveRecord.
+So what's wrong with just using <tt>Object#extend</tt>?  Nothing, until you want to avoid altering an instance's class
+as a side effect of adorning the instance it with a role... which happens often when using ActiveRecord.
 
 Consider the following use of DCI and ActiveRecord with plain old <tt>Object#extend</tt>:
 


### PR DESCRIPTION
I think the README has an incorrect negation.

Original version:

  So what’s wrong with just using Object#extend?
  Nothing, until you want to alter an instance’s class
  as a side effect of adorning it with a role…
  which happens often when using ActiveRecord.

I think you intend to say the inverse. I suggest:

  So what's wrong with just using Object#extend?
  Nothing, until you want to avoid altering an instance's class
  as a side effect of adorning the instance it with a role...
  which happens often when using ActiveRecord.

Maybe I misunderstood ?
